### PR TITLE
Use java opts values from teamcity

### DIFF
--- a/deploy/service.json
+++ b/deploy/service.json
@@ -40,7 +40,7 @@
     "SERVICE_SCOPE": "public",
     "SERVICE_TYPE": "websockets",
     "SERVICE_IMAGE": "${IMAGE_ARTIFACT}",
-    "JAVA_OPTS": "-Xmx500m",
+    "JAVA_OPTS": "${JAVA_OPTS}",
     "SERVICE_HEALTH_CHECK": "curl --show-error --silent %<host>s:%<port>s/health"
   },
   "healthChecks": [{


### PR DESCRIPTION
All services will use: `+val java_opts = "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"` from teamcity.