### PR TITLE
[OTA-3479] Use the namespace from the token scope instead of subject.

### DIFF
--- a/src/main/scala/com/advancedtelematic/web_events/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/web_events/http/Errors.scala
@@ -1,0 +1,13 @@
+package com.advancedtelematic.web_events.http
+
+import akka.http.scaladsl.model.StatusCodes
+import com.advancedtelematic.libats.data.ErrorCode
+import com.advancedtelematic.libats.http.Errors.RawError
+
+object Errors {
+  def scopeLacksNamespace(scope: Set[String]): RawError = RawError(
+    ErrorCode("missing_namespace_in_token_scope"),
+    StatusCodes.Unauthorized,
+    s"The scope of the token does not provide a namespace. Scope: $scope."
+  )
+}

--- a/src/test/scala/com/advancedtelematic/web_events/http/WebSocketResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/web_events/http/WebSocketResourceSpec.scala
@@ -93,7 +93,7 @@ class WebSocketResourceSpec extends FunSuite with Matchers with ScalaFutures wit
       Subject(namespace),
       Audience(Set("audience")),
       Instant.now().minusSeconds(120.longValue()), Instant.now().plusSeconds(120.longValue()),
-      Scope(Set("scope")))
+      Scope(Set(s"namespace.$namespace")))
     val key = new SecretKeySpec(Base64.decodeBase64(config.getString("auth.token.secret")), "HMAC")
     val potKeyInfo = KeyInfo[SecretKey, Octet, Sign :: Verify :: HNil, Hmac.HS256 :: HNil](key)
     val keyInfo = potKeyInfo.right.get


### PR DESCRIPTION
Goes with https://github.com/advancedtelematic/ota-plus-server/pull/2051.