### PR TITLE
Add batching when processing events.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,8 +19,14 @@ messaging {
     host = "localhost:9092"
     host = ${?KAFKA_HOST}
   }
-
-  listener.batch.max = 1
+  listener {
+    parallelism = 6
+    parallelism = ${?MESSAGE_LISTENER_PARALLELISM}
+    batch {
+      max = 200
+      max = ${?MESSAGE_LISTENER_BATCH_MAX}
+    }
+  }
 }
 
 auth {


### PR DESCRIPTION
We discovered that the Kafka lag for the `DeviceSeen` event is growing indefinitely in production. We expect that batching the messages and adding some parallelism will alleviate this.